### PR TITLE
Change api to get ip address from ipify to amazonaws.

### DIFF
--- a/SmartApi/smartConnect.py
+++ b/SmartApi/smartConnect.py
@@ -55,7 +55,7 @@ class SmartConnect(object):
 
 
     try:
-        clientPublicIp= " " + get('https://api.ipify.org').text
+        clientPublicIp= " " + get('https://checkip.amazonaws.com').text
         if " " in clientPublicIp:
             clientPublicIp=clientPublicIp.replace(" ","")
         hostname = socket.gethostname()


### PR DESCRIPTION
The ipify api is considerably slow and takes more than 30 seconds.
The amazonaws ip endpoint is very fast in comparison and is already used by the java version of smart connect.