### PR TITLE
Updated  smartConnect.py generateSession()

### DIFF
--- a/SmartApi/smartConnect.py
+++ b/SmartApi/smartConnect.py
@@ -234,6 +234,11 @@ class SmartConnect(object):
         
         params={"clientcode":clientCode,"password":password,"totp":totp}
         loginResultObject=self._postRequest("api.login",params)
+
+        if loginResultObject['status']==False:
+            #on failure returns the error message
+            logger.error(f"API User Session Failed: {loginResultObject['message']}")
+            return loginResultObject['message']
         
         if loginResultObject['status']==True:
             jwtToken=loginResultObject['data']['jwtToken']


### PR DESCRIPTION
Handles the failure of generateSession.

the request returns success = False on failure, with a message which is logged and returned.

The Failed returned JSON from _postRequest() is handled

Example of requests.request().content returning success = False on failure
`
{'success': False,
 'message': 'Client Is Block For Trading',
 'errorCode': 'AB1006',
 'data': ''}
`

please merge this to avoid the below errors 

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In [1], [line 27](vscode-notebook-cell:?execution_count=1&line=27)
     [24](vscode-notebook-cell:?execution_count=1&line=24)     raise e
     [26](vscode-notebook-cell:?execution_count=1&line=26) correlation_id = "abcde"
---> [27](vscode-notebook-cell:?execution_count=1&line=27) data = smartApi.generateSession(username, pwd, totp)

File [c:\Users\ankit.ka\AppData\Local\Programs\Python\Python39\lib\site-packages\SmartApi\smartConnect.py:241](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:241), in SmartConnect.generateSession(self, clientCode, password, totp)
    [237](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:237) params={"clientcode":clientCode,"password":password,"totp":totp}
    [238](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:238) loginResultObject=self._postRequest("api.login",params) 
--> [241](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:241) if loginResultObject['status']==True:
    [242](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:242)     jwtToken=loginResultObject['data']['jwtToken']
    [243](file:///C:/Users/ankit.ka/AppData/Local/Programs/Python/Python39/lib/site-packages/SmartApi/smartConnect.py:243)     self.setAccessToken(jwtToken)

KeyError: 'status'
```

