### PR TITLE
Update requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,6 @@ incremental==22.10.0
 isodate==0.6.1
 logzero==1.7.0
 pycparser==2.21
-pycrypto==2.6.1
 pyotp==2.8.0
 pyparsing==3.1.0
 python-dateutil==2.8.2


### PR DESCRIPTION
pycrypto is causing error when installing smartApi-python through pip. It is also not used anywhere in code. This commit remove it from requirements.