### PR TITLE
Update smartConnect.py - privateKey initiated with privatekey instead…

### DIFF
--- a/SmartApi/smartConnect.py
+++ b/SmartApi/smartConnect.py
@@ -100,7 +100,7 @@ class SmartConnect(object):
         self.clientLocalIP=self.clientLocalIp
         self.clientPublicIP=self.clientPublicIp
         self.clientMacAddress=self.clientMacAddress
-        self.privateKey=api_key
+        self.privateKey=privateKey
         self.accept=self.accept
         self.userType=self.userType
         self.sourceID=self.sourceID


### PR DESCRIPTION
… of apikey

In the initialization function,
privateKey variable is initiated with api key instead of privateKey.