### PR TITLE
Fix: Add timeout to external IP address retrieval to prevent indefinite blocking

### DIFF
--- a/SmartApi/smartConnect.py
+++ b/SmartApi/smartConnect.py
@@ -69,7 +69,7 @@ class SmartConnect(object):
     }
 
     try:
-        clientPublicIp= " " + get('https://api.ipify.org').text
+        clientPublicIp= " " + get('https://api.ipify.org', timeout=5).text
         if " " in clientPublicIp:
             clientPublicIp=clientPublicIp.replace(" ","")
         hostname = socket.gethostname()


### PR DESCRIPTION
## Problem

The `SmartConnect` class contains module-level code that executes on import, making HTTP requests to `api.ipify.org` without a timeout. This causes several critical issues:

1. **Indefinite blocking**: When `api.ipify.org` experiences outages (which can last hours), the `get()` call blocks indefinitely waiting for a response
2. **Import-time execution**: Since this code runs at module level (outside `__init__`), it executes whenever the module is imported, even if the class is never instantiated
3. **Cascade failures**: Any application importing this module becomes unavailable during `api.ipify.org` outages, regardless of whether `SmartConnect` is actually used

## Root Cause

```python
# This runs at import time, not at class instantiation
clientPublicIp = " " + get('https://api.ipify.org').text  # timeout is missing
```

The `requests.get()` call lacks a `timeout` parameter, causing it to wait indefinitely for a response when the external service is unavailable.

## Solution

Add a 5-second timeout to the `get()` request to ensure the import process completes within a reasonable timeframe, allowing dependent applications to continue functioning even when the external IP service is down.

## Changes

- Added `timeout=5` parameter to the `requests.get()` call
- No other functionality changes - the existing exception handling and fallback logic remain intact
- The 5-second timeout value was chosen to balance between allowing sufficient time for the request under normal conditions while preventing indefinite blocking

## Code Changes

```python
# Before
clientPublicIp = " " + get('https://api.ipify.org').text

# After  
clientPublicIp = " " + get('https://api.ipify.org', timeout=5).text
```

## Testing

- Verified that normal IP retrieval continues to work with the timeout
- Confirmed that when the service is unavailable, the code now fails fast (within 5 seconds) and falls back to the hardcoded values as intended
- Tested import behavior - modules importing `SmartConnect` no longer hang indefinitely during service outages

## Benefits

- **Improved reliability**: Applications importing this module will no longer experience indefinite hangs
- **Faster failure recovery**: 5-second timeout allows quick fallback to default IP addresses
- **Backward compatibility**: No breaking changes to existing functionality
- **Production stability**: Eliminates cascade failures during external service outages

## Risk Assessment

**Low Risk**: This is a defensive change that only affects error scenarios. Normal operation is unchanged, and the existing exception handling ensures graceful degradation when the timeout is reached.

---

**Note**: While this PR addresses the immediate blocking issue, consider refactoring the module-level execution in a future release to move IP retrieval into the class initialization or a lazy-loading pattern to further improve import performance and reliability.